### PR TITLE
APP-750 JIRA restricted comments

### DIFF
--- a/src/main/java/org/symphonyoss/integration/webhook/jira/JiraParserConstants.java
+++ b/src/main/java/org/symphonyoss/integration/webhook/jira/JiraParserConstants.java
@@ -17,6 +17,9 @@
 package org.symphonyoss.integration.webhook.jira;
 
 /**
+ * This class contains the constants to access data in the JSON payload received from JIRA, as well as constants to
+ * build the entity contained in the webhook message dispatched by the JIRA parser.
+ *
  * Created by rsanchez on 18/05/16.
  */
 public final class JiraParserConstants {
@@ -82,27 +85,20 @@ public final class JiraParserConstants {
 
   public static final String DISPLAY_NAME_PATH = "displayName";
 
+  public static final String VISIBILITY_PATH = "visibility";
+
   public static final String PROJECT_ENTITY_FIELD = "project";
   public static final String KEY_ENTITY_FIELD = "key";
   public static final String SUBJECT_ENTITY_FIELD = "subject";
   public static final String TYPE_ENTITY_FIELD = "type";
   public static final String DESCRIPTION_ENTITY_FIELD = "description";
   public static final String LINK_ENTITY_FIELD = "link";
-  public static final String ASSIGNEE_ENTITY_FIELD = "assignee";
   public static final String PRIORITY_ENTITY_FIELD = "priority";
   public static final String ISSUE_ENTITY_FIELD = "issue";
   public static final String LABELS_ENTITY_FIELD = "labels";
   public static final String EPIC_ENTITY_FIELD = "epic";
   public static final String USER_ENTITY_FIELD = "user";
-  public static final String USERNAME_ENTITY_FIELD = "username";
-  public static final String NAME_ENTITY_FIELD = "name";
-  public static final String EMAIL_ADDRESS_ENTITY_FIELD = "emailAddress";
-  public static final String DISPLAY_NAME_ENTITY_FIELD = "displayName";
   public static final String AUTHOR_ENTITY_FIELD = "author";
   public static final String COMMENT_ENTITY_FIELD = "comment";
-
-  public static final String USER_ID = "id";
-  public static final String MENTION_FIELD = "mention";
-
 
 }

--- a/src/test/java/org/symphonyoss/integration/webhook/jira/parser/CommentJiraParserTest.java
+++ b/src/test/java/org/symphonyoss/integration/webhook/jira/parser/CommentJiraParserTest.java
@@ -24,7 +24,6 @@ import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.when;
 
 import com.fasterxml.jackson.databind.JsonNode;
-import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.InjectMocks;
@@ -92,21 +91,21 @@ public class CommentJiraParserTest extends JiraParserTest {
     ClassLoader classLoader = getClass().getClassLoader();
     JsonNode node = JsonUtils.readTree(classLoader.getResourceAsStream(FILENAME_COMPLETE_REQUEST));
     String expectedMessage = readFile("parser/commentJiraParser/commentAddedMessageML.xml");
-    Assert.assertEquals(expectedMessage, this.commentJiraParser.parse(null, node));
+    assertEquals(expectedMessage, this.commentJiraParser.parse(null, node));
   }
 
   @Test
   public void testParseCommentAddedRestrictedComment() throws WebHookParseException, IOException {
     ClassLoader classLoader = getClass().getClassLoader();
     JsonNode node = JsonUtils.readTree(classLoader.getResourceAsStream(FILENAME_COMMENT_ADDED_RESTRICTED_COMMENT));
-    Assert.assertEquals(null, this.commentJiraParser.parse(null, node));
+    assertEquals(null, this.commentJiraParser.parse(null, node));
   }
 
   @Test
   public void testParseCommentUpdatedRestrictedComment() throws WebHookParseException, IOException {
     ClassLoader classLoader = getClass().getClassLoader();
     JsonNode node = JsonUtils.readTree(classLoader.getResourceAsStream(FILENAME_COMMENT_UPDATED_RESTRICTED_COMMENT));
-    Assert.assertEquals(null, this.commentJiraParser.parse(null, node));
+    assertEquals(null, this.commentJiraParser.parse(null, node));
   }
 
   @Test
@@ -114,7 +113,7 @@ public class CommentJiraParserTest extends JiraParserTest {
     ClassLoader classLoader = getClass().getClassLoader();
     JsonNode node = JsonUtils.readTree(classLoader.getResourceAsStream(FILENAME_URL_MARKUP));
     String expectedMessage = readFile("parser/commentJiraParser/commentAddedWithLinkMessageML.xml");
-    Assert.assertEquals(expectedMessage, this.commentJiraParser.parse(null, node));
+    assertEquals(expectedMessage, this.commentJiraParser.parse(null, node));
   }
 
   @Test
@@ -138,7 +137,7 @@ public class CommentJiraParserTest extends JiraParserTest {
     doReturn(returnedUserKey1).when(userService).getUserByUserName(anyString(), eq(userKey1));
     doReturn(returnedUserKey2).when(userService).getUserByUserName(anyString(), eq(userKey2));
     String actual = this.commentJiraParser.parse(null, node);
-    Assert.assertEquals(expected, actual);
+    assertEquals(expected, actual);
   }
 
   @Test
@@ -147,7 +146,7 @@ public class CommentJiraParserTest extends JiraParserTest {
     JsonNode node = JsonUtils.readTree(classLoader.getResourceAsStream(FILENAME_NO_LABELS_REQUEST));
     String expectedMessage = readFile(
         "parser/commentJiraParser/commentAddedWithoutLabelsMessageML.xml");
-    Assert.assertEquals(expectedMessage, this.commentJiraParser.parse(null, node));
+    assertEquals(expectedMessage, this.commentJiraParser.parse(null, node));
   }
 
   @Test
@@ -156,7 +155,7 @@ public class CommentJiraParserTest extends JiraParserTest {
         JsonUtils.readTree(classLoader.getResourceAsStream(FILENAME_NO_ISSUE_TYPE_REQUEST));
     String expectedMessage = readFile(
         "parser/commentJiraParser/commentAddedWithoutIssueMessageML.xml");
-    Assert.assertEquals(expectedMessage, this.commentJiraParser.parse(null, node));
+    assertEquals(expectedMessage, this.commentJiraParser.parse(null, node));
   }
 
   @Test
@@ -169,7 +168,7 @@ public class CommentJiraParserTest extends JiraParserTest {
         JsonUtils.readTree(classLoader.getResourceAsStream(FILENAME_NO_PROJECT_NAME_REQUEST));
     String expectedMessage = readFile(
         "parser/commentJiraParser/commentAddedWithoutProjectNameMessageML.xml");
-    Assert.assertEquals(expectedMessage, this.commentJiraParser.parse(null, node));
+    assertEquals(expectedMessage, this.commentJiraParser.parse(null, node));
   }
 
   @Test
@@ -179,7 +178,7 @@ public class CommentJiraParserTest extends JiraParserTest {
     String expectedMessage = readFile(
         "parser/commentJiraParser/commentAddedWithoutCommentMessageML.xml");
 
-    Assert.assertEquals(expectedMessage, this.commentJiraParser.parse(null, node));
+    assertEquals(expectedMessage, this.commentJiraParser.parse(null, node));
   }
 
   @Test
@@ -188,7 +187,7 @@ public class CommentJiraParserTest extends JiraParserTest {
     ClassLoader classLoader = getClass().getClassLoader();
     JsonNode node = JsonUtils.readTree(classLoader.getResourceAsStream(FILENAME_EMAIL_WITH_SPACE));
     String expectedMessage = readFile("parser/commentJiraParser/commentAddedMessageML.xml");
-    Assert.assertEquals(expectedMessage, this.commentJiraParser.parse(null, node));
+    assertEquals(expectedMessage, this.commentJiraParser.parse(null, node));
   }
 
   @Test

--- a/src/test/java/org/symphonyoss/integration/webhook/jira/parser/CommentJiraParserTest.java
+++ b/src/test/java/org/symphonyoss/integration/webhook/jira/parser/CommentJiraParserTest.java
@@ -46,6 +46,12 @@ public class CommentJiraParserTest extends JiraParserTest {
   private static final String FILENAME_COMPLETE_REQUEST =
       "parser/commentJiraParser/jiraCallbackSampleCommentAdded.json";
 
+  private static final String FILENAME_COMMENT_ADDED_RESTRICTED_COMMENT =
+      "parser/commentJiraParser/jiraCallbackSampleCommentAddedRestrictedComment.json";
+
+  private static final String FILENAME_COMMENT_UPDATED_RESTRICTED_COMMENT =
+      "parser/commentJiraParser/jiraCallbackSampleCommentUpdatedRestrictedComment.json";
+
   private static final String FILENAME_URL_MARKUP =
       "parser/issueUpdatedJiraParser/jiraCallbackSampleMarkUpLinkDescription.json";
 
@@ -87,6 +93,20 @@ public class CommentJiraParserTest extends JiraParserTest {
     JsonNode node = JsonUtils.readTree(classLoader.getResourceAsStream(FILENAME_COMPLETE_REQUEST));
     String expectedMessage = readFile("parser/commentJiraParser/commentAddedMessageML.xml");
     Assert.assertEquals(expectedMessage, this.commentJiraParser.parse(null, node));
+  }
+
+  @Test
+  public void testParseCommentAddedRestrictedComment() throws WebHookParseException, IOException {
+    ClassLoader classLoader = getClass().getClassLoader();
+    JsonNode node = JsonUtils.readTree(classLoader.getResourceAsStream(FILENAME_COMMENT_ADDED_RESTRICTED_COMMENT));
+    Assert.assertEquals(null, this.commentJiraParser.parse(null, node));
+  }
+
+  @Test
+  public void testParseCommentUpdatedRestrictedComment() throws WebHookParseException, IOException {
+    ClassLoader classLoader = getClass().getClassLoader();
+    JsonNode node = JsonUtils.readTree(classLoader.getResourceAsStream(FILENAME_COMMENT_UPDATED_RESTRICTED_COMMENT));
+    Assert.assertEquals(null, this.commentJiraParser.parse(null, node));
   }
 
   @Test

--- a/src/test/resources/parser/commentJiraParser/jiraCallbackSampleCommentAddedRestrictedComment.json
+++ b/src/test/resources/parser/commentJiraParser/jiraCallbackSampleCommentAddedRestrictedComment.json
@@ -1,0 +1,316 @@
+{
+  "timestamp": 1463578203491,
+  "webhookEvent": "jira:issue_updated",
+  "issue_event_type_name": "issue_commented",
+  "user": {
+    "self": "https://whiteam1.atlassian.net/rest/api/2/user?username=test",
+    "name": "test",
+    "key": "test",
+    "emailAddress": "test@symphony.com",
+    "avatarUrls": {
+      "48x48": "https://whiteam1.atlassian.net/secure/useravatar?avatarId=10334",
+      "24x24": "https://whiteam1.atlassian.net/secure/useravatar?size=small&avatarId=10334",
+      "16x16": "https://whiteam1.atlassian.net/secure/useravatar?size=xsmall&avatarId=10334",
+      "32x32": "https://whiteam1.atlassian.net/secure/useravatar?size=medium&avatarId=10334"
+    },
+    "displayName": "Test User",
+    "active": true,
+    "timeZone": "America/Sao_Paulo"
+  },
+  "issue": {
+    "id": "10100",
+    "self": "https://whiteam1.atlassian.net/rest/api/2/issue/10100",
+    "key": "SAM-25",
+    "fields": {
+      "issuetype": {
+        "self": "https://whiteam1.atlassian.net/rest/api/2/issuetype/10001",
+        "id": "10001",
+        "description": "gh.issue.story.desc",
+        "iconUrl": "https://whiteam1.atlassian.net/images/icons/issuetypes/story.svg",
+        "name": "Story",
+        "subtask": false
+      },
+      "timespent": null,
+      "project": {
+        "self": "https://whiteam1.atlassian.net/rest/api/2/project/10000",
+        "id": "10000",
+        "key": "SAM",
+        "name": "Sample 1",
+        "avatarUrls": {
+          "48x48": "https://whiteam1.atlassian.net/secure/projectavatar?avatarId=10324",
+          "24x24": "https://whiteam1.atlassian.net/secure/projectavatar?size=small&avatarId=10324",
+          "16x16": "https://whiteam1.atlassian.net/secure/projectavatar?size=xsmall&avatarId=10324",
+          "32x32": "https://whiteam1.atlassian.net/secure/projectavatar?size=medium&avatarId=10324"
+        }
+      },
+      "fixVersions": [
+        {
+          "self": "https://whiteam1.atlassian.net/rest/api/2/version/10001",
+          "id": "10001",
+          "name": "Version 2.0",
+          "archived": false,
+          "released": false,
+          "releaseDate": "2016-05-23"
+        }
+      ],
+      "aggregatetimespent": null,
+      "resolution": null,
+      "resolutiondate": null,
+      "workratio": -1,
+      "lastViewed": "2016-05-18T10:30:03.486-0300",
+      "watches": {
+        "self": "https://whiteam1.atlassian.net/rest/api/2/issue/SAM-25/watchers",
+        "watchCount": 2,
+        "isWatching": true
+      },
+      "created": "2016-05-18T10:10:43.584-0300",
+      "customfield_10020": null,
+      "customfield_10021": "Not started",
+      "customfield_10022": null,
+      "priority": {
+        "self": "https://whiteam1.atlassian.net/rest/api/2/priority/1",
+        "iconUrl": "https://whiteam1.atlassian.net/images/icons/priorities/highest.svg",
+        "name": "Highest",
+        "id": "1"
+      },
+      "labels": [
+        "#production",
+        "#test"
+      ],
+      "customfield_10016": null,
+      "customfield_10017": null,
+      "customfield_10018": null,
+      "customfield_10019": null,
+      "timeestimate": null,
+      "aggregatetimeoriginalestimate": null,
+      "versions": [],
+      "issuelinks": [],
+      "assignee": {
+        "self": "https://whiteam1.atlassian.net/rest/api/2/user?username=test",
+        "name": "test",
+        "key": "test",
+        "emailAddress": "test@symphony.com",
+        "avatarUrls": {
+          "48x48": "https://whiteam1.atlassian.net/secure/useravatar?avatarId=10334",
+          "24x24": "https://whiteam1.atlassian.net/secure/useravatar?size=small&avatarId=10334",
+          "16x16": "https://whiteam1.atlassian.net/secure/useravatar?size=xsmall&avatarId=10334",
+          "32x32": "https://whiteam1.atlassian.net/secure/useravatar?size=medium&avatarId=10334"
+        },
+        "displayName": "Test User",
+        "active": true,
+        "timeZone": "America/Sao_Paulo"
+      },
+      "updated": "2016-05-18T10:30:03.490-0300",
+      "status": {
+        "self": "https://whiteam1.atlassian.net/rest/api/2/status/10000",
+        "description": "",
+        "iconUrl": "https://whiteam1.atlassian.net/",
+        "name": "To Do",
+        "id": "10000",
+        "statusCategory": {
+          "self": "https://whiteam1.atlassian.net/rest/api/2/statuscategory/2",
+          "id": 2,
+          "key": "new",
+          "colorName": "blue-gray",
+          "name": "To Do"
+        }
+      },
+      "components": [],
+      "timeoriginalestimate": null,
+      "description": "Only for test",
+      "customfield_10010": null,
+      "customfield_10011": null,
+      "customfield_10012": null,
+      "customfield_10013": null,
+      "customfield_10014": null,
+      "timetracking": {},
+      "customfield_10015": null,
+      "customfield_10008": null,
+      "attachment": [],
+      "customfield_10009": "com.atlassian.servicedesk.plugins.approvals.internal.customfield.ApprovalsCFValue@ace1b1",
+      "aggregatetimeestimate": null,
+      "summary": "Issue Test",
+      "creator": {
+        "self": "https://whiteam1.atlassian.net/rest/api/2/user?username=robso",
+        "name": "robso",
+        "key": "robsonvinicius",
+        "emailAddress": "robsonvinicius@gmail.com",
+        "avatarUrls": {
+          "48x48": "https://secure.gravatar.com/avatar/5bba6a42b432edbddb2852f8da58ea84?d=mm&s=48",
+          "24x24": "https://secure.gravatar.com/avatar/5bba6a42b432edbddb2852f8da58ea84?d=mm&s=24",
+          "16x16": "https://secure.gravatar.com/avatar/5bba6a42b432edbddb2852f8da58ea84?d=mm&s=16",
+          "32x32": "https://secure.gravatar.com/avatar/5bba6a42b432edbddb2852f8da58ea84?d=mm&s=32"
+        },
+        "displayName": "Robson",
+        "active": true,
+        "timeZone": "America/Sao_Paulo"
+      },
+      "subtasks": [],
+      "reporter": {
+        "self": "https://whiteam1.atlassian.net/rest/api/2/user?username=robso",
+        "name": "robso",
+        "key": "robsonvinicius",
+        "emailAddress": "robsonvinicius@gmail.com",
+        "avatarUrls": {
+          "48x48": "https://secure.gravatar.com/avatar/5bba6a42b432edbddb2852f8da58ea84?d=mm&s=48",
+          "24x24": "https://secure.gravatar.com/avatar/5bba6a42b432edbddb2852f8da58ea84?d=mm&s=24",
+          "16x16": "https://secure.gravatar.com/avatar/5bba6a42b432edbddb2852f8da58ea84?d=mm&s=16",
+          "32x32": "https://secure.gravatar.com/avatar/5bba6a42b432edbddb2852f8da58ea84?d=mm&s=32"
+        },
+        "displayName": "Robson",
+        "active": true,
+        "timeZone": "America/Sao_Paulo"
+      },
+      "customfield_10000": "2016-05-18T10:25:44.154-0300",
+      "aggregateprogress": {
+        "progress": 0,
+        "total": 0
+      },
+      "customfield_10001": null,
+      "customfield_10002": "0|i0002z:",
+      "customfield_10003": [
+        "com.atlassian.greenhopper.service.sprint.Sprint@df3421[id=6,rapidViewId=1,state=ACTIVE,name=Sample Sprint 6,startDate=2016-05-18T10:29:45.499-03:00,endDate=2016-06-01T10:29:00.000-03:00,completeDate=<null>,sequence=6]"
+      ],
+      "customfield_10004": null,
+      "environment": null,
+      "duedate": null,
+      "progress": {
+        "progress": 0,
+        "total": 0
+      },
+      "comment": {
+        "startAt": 0,
+        "maxResults": 2,
+        "total": 2,
+        "comments": [
+          {
+            "self": "https://whiteam1.atlassian.net/rest/api/2/issue/10100/comment/10105",
+            "id": "10105",
+            "author": {
+              "self": "https://whiteam1.atlassian.net/rest/api/2/user?username=test",
+              "name": "test",
+              "key": "test",
+              "emailAddress": "test@symphony.com",
+              "avatarUrls": {
+                "48x48": "https://whiteam1.atlassian.net/secure/useravatar?avatarId=10334",
+                "24x24": "https://whiteam1.atlassian.net/secure/useravatar?size=small&avatarId=10334",
+                "16x16": "https://whiteam1.atlassian.net/secure/useravatar?size=xsmall&avatarId=10334",
+                "32x32": "https://whiteam1.atlassian.net/secure/useravatar?size=medium&avatarId=10334"
+              },
+              "displayName": "Milton2",
+              "active": true,
+              "timeZone": "America/Sao_Paulo"
+            },
+            "body":"Hey, this is another test comment!",
+            "updateAuthor": {
+              "self": "https://whiteam1.atlassian.net/rest/api/2/user?username=test",
+              "name": "test",
+              "key": "test",
+              "emailAddress": "test@symphony.com",
+              "avatarUrls": {
+                "48x48": "https://whiteam1.atlassian.net/secure/useravatar?avatarId=10334",
+                "24x24": "https://whiteam1.atlassian.net/secure/useravatar?size=small&avatarId=10334",
+                "16x16": "https://whiteam1.atlassian.net/secure/useravatar?size=xsmall&avatarId=10334",
+                "32x32": "https://whiteam1.atlassian.net/secure/useravatar?size=medium&avatarId=10334"
+              },
+              "displayName": "Milton2",
+              "active": true,
+              "timeZone": "America/Sao_Paulo"
+            },
+            "created": "2016-05-18T10:25:44.154-0300",
+            "updated": "2016-05-18T10:25:44.154-0300"
+          },
+          {
+            "self": "https://whiteam1.atlassian.net/rest/api/2/issue/10100/comment/10106",
+            "id": "10106",
+            "author": {
+              "self": "https://whiteam1.atlassian.net/rest/api/2/user?username=test",
+              "name": "test",
+              "key": "test",
+              "emailAddress": "test@symphony.com",
+              "avatarUrls": {
+                "48x48": "https://whiteam1.atlassian.net/secure/useravatar?avatarId=10334",
+                "24x24": "https://whiteam1.atlassian.net/secure/useravatar?size=small&avatarId=10334",
+                "16x16": "https://whiteam1.atlassian.net/secure/useravatar?size=xsmall&avatarId=10334",
+                "32x32": "https://whiteam1.atlassian.net/secure/useravatar?size=medium&avatarId=10334"
+              },
+              "displayName": "Milton2",
+              "active": true,
+              "timeZone": "America/Sao_Paulo"
+            },
+            "body":"Hey, this is another test comment!",
+            "updateAuthor": {
+              "self": "https://whiteam1.atlassian.net/rest/api/2/user?username=test",
+              "name": "test",
+              "key": "test",
+              "emailAddress": "test@symphony.com",
+              "avatarUrls": {
+                "48x48": "https://whiteam1.atlassian.net/secure/useravatar?avatarId=10334",
+                "24x24": "https://whiteam1.atlassian.net/secure/useravatar?size=small&avatarId=10334",
+                "16x16": "https://whiteam1.atlassian.net/secure/useravatar?size=xsmall&avatarId=10334",
+                "32x32": "https://whiteam1.atlassian.net/secure/useravatar?size=medium&avatarId=10334"
+              },
+              "displayName": "Milton2",
+              "active": true,
+              "timeZone": "America/Sao_Paulo"
+            },
+            "created": "2016-05-18T10:30:03.488-0300",
+            "updated": "2016-05-18T10:30:03.488-0300"
+          }
+        ]
+      },
+      "votes": {
+        "self": "https://whiteam1.atlassian.net/rest/api/2/issue/SAM-25/votes",
+        "votes": 0,
+        "hasVoted": false
+      },
+      "worklog": {
+        "startAt": 0,
+        "maxResults": 20,
+        "total": 0,
+        "worklogs": []
+      }
+    }
+  },
+  "comment": {
+    "self": "https://whiteam1.atlassian.net/rest/api/2/issue/10100/comment/10106",
+    "id": "10106",
+    "author": {
+      "self": "https://whiteam1.atlassian.net/rest/api/2/user?username=test",
+      "name": "test",
+      "key": "test",
+      "emailAddress": "test@symphony.com",
+      "avatarUrls": {
+        "48x48": "https://whiteam1.atlassian.net/secure/useravatar?avatarId=10334",
+        "24x24": "https://whiteam1.atlassian.net/secure/useravatar?size=small&avatarId=10334",
+        "16x16": "https://whiteam1.atlassian.net/secure/useravatar?size=xsmall&avatarId=10334",
+        "32x32": "https://whiteam1.atlassian.net/secure/useravatar?size=medium&avatarId=10334"
+      },
+      "displayName": "Milton2",
+      "active": true,
+      "timeZone": "America/Sao_Paulo"
+    },
+    "body":"Hey, this is another test comment!",
+    "updateAuthor": {
+      "self": "https://whiteam1.atlassian.net/rest/api/2/user?username=test",
+      "name": "test",
+      "key": "test",
+      "emailAddress": "test@symphony.com",
+      "avatarUrls": {
+        "48x48": "https://whiteam1.atlassian.net/secure/useravatar?avatarId=10334",
+        "24x24": "https://whiteam1.atlassian.net/secure/useravatar?size=small&avatarId=10334",
+        "16x16": "https://whiteam1.atlassian.net/secure/useravatar?size=xsmall&avatarId=10334",
+        "32x32": "https://whiteam1.atlassian.net/secure/useravatar?size=medium&avatarId=10334"
+      },
+      "displayName": "Milton2",
+      "active": true,
+      "timeZone": "America/Sao_Paulo"
+    },
+    "created": "2016-05-18T10:30:03.488-0300",
+    "updated": "2016-05-18T10:30:03.488-0300",
+    "visibility": {
+      "type": "role",
+      "value": "Administrators"
+    }
+  }
+}

--- a/src/test/resources/parser/commentJiraParser/jiraCallbackSampleCommentUpdatedRestrictedComment.json
+++ b/src/test/resources/parser/commentJiraParser/jiraCallbackSampleCommentUpdatedRestrictedComment.json
@@ -1,0 +1,266 @@
+{
+  "timestamp": 1469730591098,
+  "webhookEvent": "jira:issue_updated",
+  "issue_event_type_name": "issue_comment_edited",
+  "user": {
+    "self": "https://ppires.atlassian.net/rest/api/2/user?username=mquilzini",
+    "name": "mquilzini",
+    "key": "mquilzini",
+    "emailAddress": "mquilzini@symphony.com",
+    "avatarUrls": {
+      "48x48": "https://secure.gravatar.com/avatar/157d6261750d7c279348e26b63d8912e?d=mm&s=48",
+      "24x24": "https://secure.gravatar.com/avatar/157d6261750d7c279348e26b63d8912e?d=mm&s=24",
+      "16x16": "https://secure.gravatar.com/avatar/157d6261750d7c279348e26b63d8912e?d=mm&s=16",
+      "32x32": "https://secure.gravatar.com/avatar/157d6261750d7c279348e26b63d8912e?d=mm&s=32"
+    },
+    "displayName": "Milton Gonçalves Quilzini",
+    "active": true,
+    "timeZone": "America/Sao_Paulo"
+  },
+  "issue": {
+    "id": "10201",
+    "self": "https://ppires.atlassian.net/rest/api/2/issue/10201",
+    "key": "ADM5-2",
+    "fields": {
+      "issuetype": {
+        "self": "https://ppires.atlassian.net/rest/api/2/issuetype/10000",
+        "id": "10000",
+        "description": "A user story. Created by JIRA Software - do not edit or delete.",
+        "iconUrl": "https://ppires.atlassian.net/secure/viewavatar?size=xsmall&avatarId=10315&avatarType=issuetype",
+        "name": "Story",
+        "subtask": false,
+        "avatarId": 10315
+      },
+      "timespent": null,
+      "project": {
+        "self": "https://ppires.atlassian.net/rest/api/2/project/10001",
+        "id": "10001",
+        "key": "ADM5",
+        "name": "admin's Project",
+        "avatarUrls": {
+          "48x48": "https://ppires.atlassian.net/secure/projectavatar?avatarId=10324",
+          "24x24": "https://ppires.atlassian.net/secure/projectavatar?size=small&avatarId=10324",
+          "16x16": "https://ppires.atlassian.net/secure/projectavatar?size=xsmall&avatarId=10324",
+          "32x32": "https://ppires.atlassian.net/secure/projectavatar?size=medium&avatarId=10324"
+        }
+      },
+      "fixVersions": [],
+      "aggregatetimespent": null,
+      "resolution": null,
+      "resolutiondate": null,
+      "workratio": -1,
+      "lastViewed": "2016-07-28T15:29:37.689-0300",
+      "watches": {
+        "self": "https://ppires.atlassian.net/rest/api/2/issue/ADM5-2/watchers",
+        "watchCount": 1,
+        "isWatching": true
+      },
+      "created": "2016-07-28T15:28:25.345-0300",
+      "customfield_10020": null,
+      "customfield_10021": "0|i0001r:",
+      "customfield_10022": null,
+      "priority": {
+        "self": "https://ppires.atlassian.net/rest/api/2/priority/3",
+        "iconUrl": "https://ppires.atlassian.net/images/icons/priorities/medium.svg",
+        "name": "Medium",
+        "id": "3"
+      },
+      "labels": [],
+      "customfield_10016": null,
+      "timeestimate": null,
+      "aggregatetimeoriginalestimate": null,
+      "versions": [],
+      "issuelinks": [],
+      "assignee": {
+        "self": "https://ppires.atlassian.net/rest/api/2/user?username=admin",
+        "name": "admin",
+        "key": "admin",
+        "emailAddress": "ppires@symphony.com",
+        "avatarUrls": {
+          "48x48": "https://secure.gravatar.com/avatar/57b0bd940cf66cd2e2ccc82a02287b70?d=mm&s=48",
+          "24x24": "https://secure.gravatar.com/avatar/57b0bd940cf66cd2e2ccc82a02287b70?d=mm&s=24",
+          "16x16": "https://secure.gravatar.com/avatar/57b0bd940cf66cd2e2ccc82a02287b70?d=mm&s=16",
+          "32x32": "https://secure.gravatar.com/avatar/57b0bd940cf66cd2e2ccc82a02287b70?d=mm&s=32"
+        },
+        "displayName": "Paulo  [Administrator]",
+        "active": true,
+        "timeZone": "America/Sao_Paulo"
+      },
+      "updated": "2016-07-28T15:28:55.960-0300",
+      "status": {
+        "self": "https://ppires.atlassian.net/rest/api/2/status/10000",
+        "description": "",
+        "iconUrl": "https://ppires.atlassian.net/",
+        "name": "To Do",
+        "id": "10000",
+        "statusCategory": {
+          "self": "https://ppires.atlassian.net/rest/api/2/statuscategory/2",
+          "id": 2,
+          "key": "new",
+          "colorName": "blue-gray",
+          "name": "To Do"
+        }
+      },
+      "components": [],
+      "timeoriginalestimate": null,
+      "description": null,
+      "customfield_10010": null,
+      "customfield_10011": null,
+      "customfield_10012": null,
+      "customfield_10013": "Not started",
+      "customfield_10014": null,
+      "timetracking": {},
+      "customfield_10015": "com.atlassian.servicedesk.plugins.approvals.internal.customfield.ApprovalsCFValue@9fc9c7",
+      "customfield_10005": null,
+      "customfield_10006": null,
+      "customfield_10007": null,
+      "customfield_10008": null,
+      "attachment": [],
+      "customfield_10009": null,
+      "aggregatetimeestimate": null,
+      "summary": "Test Story",
+      "creator": {
+        "self": "https://ppires.atlassian.net/rest/api/2/user?username=mquilzini",
+        "name": "mquilzini",
+        "key": "mquilzini",
+        "emailAddress": "mquilzini@symphony.com",
+        "avatarUrls": {
+          "48x48": "https://secure.gravatar.com/avatar/157d6261750d7c279348e26b63d8912e?d=mm&s=48",
+          "24x24": "https://secure.gravatar.com/avatar/157d6261750d7c279348e26b63d8912e?d=mm&s=24",
+          "16x16": "https://secure.gravatar.com/avatar/157d6261750d7c279348e26b63d8912e?d=mm&s=16",
+          "32x32": "https://secure.gravatar.com/avatar/157d6261750d7c279348e26b63d8912e?d=mm&s=32"
+        },
+        "displayName": "Milton Gonçalves Quilzini",
+        "active": true,
+        "timeZone": "America/Sao_Paulo"
+      },
+      "subtasks": [],
+      "reporter": {
+        "self": "https://ppires.atlassian.net/rest/api/2/user?username=mquilzini",
+        "name": "mquilzini",
+        "key": "mquilzini",
+        "emailAddress": "mquilzini@symphony.com",
+        "avatarUrls": {
+          "48x48": "https://secure.gravatar.com/avatar/157d6261750d7c279348e26b63d8912e?d=mm&s=48",
+          "24x24": "https://secure.gravatar.com/avatar/157d6261750d7c279348e26b63d8912e?d=mm&s=24",
+          "16x16": "https://secure.gravatar.com/avatar/157d6261750d7c279348e26b63d8912e?d=mm&s=16",
+          "32x32": "https://secure.gravatar.com/avatar/157d6261750d7c279348e26b63d8912e?d=mm&s=32"
+        },
+        "displayName": "Milton Gonçalves Quilzini",
+        "active": true,
+        "timeZone": "America/Sao_Paulo"
+      },
+      "customfield_10000": null,
+      "aggregateprogress": {
+        "progress": 0,
+        "total": 0
+      },
+      "customfield_10001": null,
+      "customfield_10002": null,
+      "customfield_10003": null,
+      "customfield_10004": null,
+      "environment": null,
+      "duedate": null,
+      "progress": {
+        "progress": 0,
+        "total": 0
+      },
+      "comment": {
+        "comments": [
+          {
+            "self": "https://ppires.atlassian.net/rest/api/2/issue/10201/comment/10200",
+            "id": "10200",
+            "author": {
+              "self": "https://ppires.atlassian.net/rest/api/2/user?username=mquilzini",
+              "name": "mquilzini",
+              "key": "mquilzini",
+              "emailAddress": "mquilzini@symphony.com",
+              "avatarUrls": {
+                "48x48": "https://secure.gravatar.com/avatar/157d6261750d7c279348e26b63d8912e?d=mm&s=48",
+                "24x24": "https://secure.gravatar.com/avatar/157d6261750d7c279348e26b63d8912e?d=mm&s=24",
+                "16x16": "https://secure.gravatar.com/avatar/157d6261750d7c279348e26b63d8912e?d=mm&s=16",
+                "32x32": "https://secure.gravatar.com/avatar/157d6261750d7c279348e26b63d8912e?d=mm&s=32"
+              },
+              "displayName": "Milton Gonçalves Quilzini",
+              "active": true,
+              "timeZone": "America/Sao_Paulo"
+            },
+            "body": "Comment Edited...",
+            "updateAuthor": {
+              "self": "https://ppires.atlassian.net/rest/api/2/user?username=mquilzini",
+              "name": "mquilzini",
+              "key": "mquilzini",
+              "emailAddress": "mquilzini@symphony.com",
+              "avatarUrls": {
+                "48x48": "https://secure.gravatar.com/avatar/157d6261750d7c279348e26b63d8912e?d=mm&s=48",
+                "24x24": "https://secure.gravatar.com/avatar/157d6261750d7c279348e26b63d8912e?d=mm&s=24",
+                "16x16": "https://secure.gravatar.com/avatar/157d6261750d7c279348e26b63d8912e?d=mm&s=16",
+                "32x32": "https://secure.gravatar.com/avatar/157d6261750d7c279348e26b63d8912e?d=mm&s=32"
+              },
+              "displayName": "Milton Gonçalves Quilzini",
+              "active": true,
+              "timeZone": "America/Sao_Paulo"
+            },
+            "created": "2016-07-28T15:28:55.960-0300",
+            "updated": "2016-07-28T15:29:51.047-0300"
+          }
+        ],
+        "maxResults": 1,
+        "total": 1,
+        "startAt": 0
+      },
+      "votes": {
+        "self": "https://ppires.atlassian.net/rest/api/2/issue/ADM5-2/votes",
+        "votes": 0,
+        "hasVoted": false
+      },
+      "worklog": {
+        "startAt": 0,
+        "maxResults": 20,
+        "total": 0,
+        "worklogs": []
+      }
+    }
+  },
+  "comment": {
+    "self": "https://ppires.atlassian.net/rest/api/2/issue/10201/comment/10200",
+    "id": "10200",
+    "author": {
+      "self": "https://ppires.atlassian.net/rest/api/2/user?username=mquilzini",
+      "name": "mquilzini",
+      "key": "mquilzini",
+      "emailAddress": "mquilzini@symphony.com",
+      "avatarUrls": {
+        "48x48": "https://secure.gravatar.com/avatar/157d6261750d7c279348e26b63d8912e?d=mm&s=48",
+        "24x24": "https://secure.gravatar.com/avatar/157d6261750d7c279348e26b63d8912e?d=mm&s=24",
+        "16x16": "https://secure.gravatar.com/avatar/157d6261750d7c279348e26b63d8912e?d=mm&s=16",
+        "32x32": "https://secure.gravatar.com/avatar/157d6261750d7c279348e26b63d8912e?d=mm&s=32"
+      },
+      "displayName": "Milton Gonçalves Quilzini",
+      "active": true,
+      "timeZone": "America/Sao_Paulo"
+    },
+    "body": "Comment Edited...",
+    "updateAuthor": {
+      "self": "https://ppires.atlassian.net/rest/api/2/user?username=mquilzini",
+      "name": "mquilzini",
+      "key": "mquilzini",
+      "emailAddress": "mquilzini@symphony.com",
+      "avatarUrls": {
+        "48x48": "https://secure.gravatar.com/avatar/157d6261750d7c279348e26b63d8912e?d=mm&s=48",
+        "24x24": "https://secure.gravatar.com/avatar/157d6261750d7c279348e26b63d8912e?d=mm&s=24",
+        "16x16": "https://secure.gravatar.com/avatar/157d6261750d7c279348e26b63d8912e?d=mm&s=16",
+        "32x32": "https://secure.gravatar.com/avatar/157d6261750d7c279348e26b63d8912e?d=mm&s=32"
+      },
+      "displayName": "Milton Gonçalves Quilzini",
+      "active": true,
+      "timeZone": "America/Sao_Paulo"
+    },
+    "created": "2016-07-28T15:28:55.960-0300",
+    "updated": "2016-07-28T15:29:51.047-0300",
+    "visibility": {
+      "type": "role",
+      "value": "Administrators"
+    }
+  }
+}

--- a/src/test/resources/parser/issueCreatedJiraParser/jiraMessageMLIssueCreated.xml
+++ b/src/test/resources/parser/issueCreatedJiraParser/jiraMessageMLIssueCreated.xml
@@ -1,5 +1,5 @@
 <entity type="com.symphony.integration.jira.event.created" version="1.0">
-<presentationML>Test User created Story SAM-25, Issue Test (<a href="https://whiteam1.atlassian.net/browse/SAM-25"/>)<br/>Assignee: Test2 User<br/>Labels: <hash tag="production"/><br/>Priority: Highest<br/>Status: To Do<br/>Description: Only &amp;lt;br /&amp;gt;for &amp;lt;b&amp;gt;test&amp;lt;/b&amp;gt; line break&lt;br/&gt; &amp;lt;code&amp;gt;test&amp;lt;/code&amp;gt;</presentationML>
+<presentationML>Test User created Story SAM-25, Issue Test (<a href="https://whiteam1.atlassian.net/browse/SAM-25"/>)<br/>Assignee: Test2 User<br/>Labels: <hash tag="production"/><br/>Priority: Highest<br/>Status: To Do<br/>Description: Only &lt;br /&gt;for &lt;b&gt;test&lt;/b&gt; line break<br/> &lt;code&gt;test&lt;/code&gt;</presentationML>
 <entity name="user" type="com.symphony.integration.jira.user" version="1.0">
 <attribute name="username" type="org.symphonyoss.string" value="test"/>
 <attribute name="emailAddress" type="org.symphonyoss.string" value="test@symphony.com"/>


### PR DESCRIPTION
Adding logic and test cases to handle restricted comments.

Comment added/edited events containing restricted comments will be ignored and not pushed as an event into Symphony IM and Chat rooms.
