### PR TITLE
App 874 - Updating an epic link to null value

### DIFF
--- a/src/main/java/org/symphonyoss/integration/webhook/jira/JiraParserConstants.java
+++ b/src/main/java/org/symphonyoss/integration/webhook/jira/JiraParserConstants.java
@@ -71,6 +71,8 @@ public final class JiraParserConstants {
 
   public static final String STATUS_PATH = "status";
 
+  public static final String TO_PATH = "to";
+
   public static final String TOSTRING_PATH = "toString";
 
   public static final String FROMSTRING_PATH = "fromString";

--- a/src/main/java/org/symphonyoss/integration/webhook/jira/parser/IssueJiraParser.java
+++ b/src/main/java/org/symphonyoss/integration/webhook/jira/parser/IssueJiraParser.java
@@ -508,7 +508,10 @@ public abstract class IssueJiraParser extends CommonJiraParser {
       JsonNode item = items.get(i);
       String field = item.get(FIELD_PATH).asText();
       if (EPIC_LINK_PATH.equals(field)) {
-        return item.get(TOSTRING_PATH).asText();
+        JsonNode toStringAttribute = item.get(TOSTRING_PATH);
+        if (!toStringAttribute.isNull()) {
+          return toStringAttribute.asText();
+        }
       }
     }
 

--- a/src/main/java/org/symphonyoss/integration/webhook/jira/parser/IssueUpdatedJiraParser.java
+++ b/src/main/java/org/symphonyoss/integration/webhook/jira/parser/IssueUpdatedJiraParser.java
@@ -111,10 +111,12 @@ public class IssueUpdatedJiraParser extends IssueJiraParser implements JiraParse
     for (int i = 0; i < items.size(); i++) {
       JsonNode item = items.get(i);
 
+      String toStringAttribute = item.get(TOSTRING_PATH).isNull() ? "" : item.get(TOSTRING_PATH).asText();
+
       changesBuilder.nestedEntity(EntityBuilder.forNestedEntity(JIRA, "change")
           .attribute("fieldName", item.get(FIELD_PATH).asText())
           .attribute("oldValue", item.get(FROMSTRING_PATH).asText())
-          .attribute("newValue", item.get(TOSTRING_PATH).asText()).build());
+          .attribute("newValue", toStringAttribute).build());
     }
     return changesBuilder.build();
   }

--- a/src/main/java/org/symphonyoss/integration/webhook/jira/parser/IssueUpdatedJiraParser.java
+++ b/src/main/java/org/symphonyoss/integration/webhook/jira/parser/IssueUpdatedJiraParser.java
@@ -111,7 +111,8 @@ public class IssueUpdatedJiraParser extends IssueJiraParser implements JiraParse
     for (int i = 0; i < items.size(); i++) {
       JsonNode item = items.get(i);
 
-      String toStringAttribute = item.get(TOSTRING_PATH).isNull() ? "" : item.get(TOSTRING_PATH).asText();
+      String toStringAttribute = item.get(TOSTRING_PATH).isNull() ? StringUtils.EMPTY
+                : item.get(TOSTRING_PATH).asText();
 
       changesBuilder.nestedEntity(EntityBuilder.forNestedEntity(JIRA, "change")
           .attribute("fieldName", item.get(FIELD_PATH).asText())

--- a/src/test/java/org/symphonyoss/integration/webhook/jira/parser/IssueUpdatedJiraParsetTest.java
+++ b/src/test/java/org/symphonyoss/integration/webhook/jira/parser/IssueUpdatedJiraParsetTest.java
@@ -16,16 +16,8 @@
 
 package org.symphonyoss.integration.webhook.jira.parser;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.mockito.Matchers.anyString;
-import static org.mockito.Matchers.eq;
-import static org.mockito.Mockito.doReturn;
-import static org.symphonyoss.integration.webhook.jira.JiraParserConstants.ASSIGNEE_PATH;
-import static org.symphonyoss.integration.webhook.jira.JiraParserConstants.FIELDS_PATH;
-import static org.symphonyoss.integration.webhook.jira.JiraParserConstants.ISSUE_PATH;
-
 import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -38,6 +30,13 @@ import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.doReturn;
+import static org.symphonyoss.integration.webhook.jira.JiraParserConstants.*;
+
 /**
  * Test class to validate {@link IssueCreatedJiraParser}
  *
@@ -47,6 +46,7 @@ import java.util.Map;
 public class IssueUpdatedJiraParsetTest extends JiraParserTest {
 
   private static final String FILENAME = "parser/issueUpdatedJiraParser/jiraCallbackSampleIssueUpdated.json";
+  private static final String EPIC_FILENAME = "parser/issueUpdatedJiraParser/jiraCallbackSampleIssueEpicUpdated.json";
 
   @InjectMocks
   private JiraParser issueUpdated = new IssueUpdatedJiraParser();
@@ -112,6 +112,32 @@ public class IssueUpdatedJiraParsetTest extends JiraParserTest {
 
     String expected = readFile("parser/issueUpdatedJiraParser/issueUpdatedWithoutChangeLogMessageML.xml");
 
+    assertEquals(expected, result);
+  }
+
+  @Test
+  public void testIssueUpdatedEpicToNull() throws IOException, JiraParserException {
+    ClassLoader classLoader = getClass().getClassLoader();
+    Map<String, String> parameters = new HashMap<>();
+
+    JsonNode node = JsonUtils.readTree(classLoader.getResourceAsStream(EPIC_FILENAME));
+    ArrayNode items = (ArrayNode)node.path(CHANGELOG_PATH).path(ITEMS_PATH);
+    for (int i = 0; i < items.size(); i++) {
+      ObjectNode item = (ObjectNode) items.get(i);
+      String field = item.get(FIELD_PATH).asText();
+      if (EPIC_LINK_PATH.equals(field)) {
+        item.remove(TO_PATH);
+        item.putNull(TO_PATH);
+        item.remove(TOSTRING_PATH);
+        item.putNull(TOSTRING_PATH);
+      }
+    }
+
+    String result = issueUpdated.parse(parameters, node);
+
+    assertNotNull(result);
+
+    String expected = readFile("parser/issueUpdatedJiraParser/issueUpdatedEpicNullMessageML.xml");
     assertEquals(expected, result);
   }
 }

--- a/src/test/java/org/symphonyoss/integration/webhook/jira/parser/IssueUpdatedJiraParsetTest.java
+++ b/src/test/java/org/symphonyoss/integration/webhook/jira/parser/IssueUpdatedJiraParsetTest.java
@@ -17,7 +17,6 @@
 package org.symphonyoss.integration.webhook.jira.parser;
 
 import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -121,17 +120,6 @@ public class IssueUpdatedJiraParsetTest extends JiraParserTest {
     Map<String, String> parameters = new HashMap<>();
 
     JsonNode node = JsonUtils.readTree(classLoader.getResourceAsStream(EPIC_FILENAME));
-    ArrayNode items = (ArrayNode)node.path(CHANGELOG_PATH).path(ITEMS_PATH);
-    for (int i = 0; i < items.size(); i++) {
-      ObjectNode item = (ObjectNode) items.get(i);
-      String field = item.get(FIELD_PATH).asText();
-      if (EPIC_LINK_PATH.equals(field)) {
-        item.remove(TO_PATH);
-        item.putNull(TO_PATH);
-        item.remove(TOSTRING_PATH);
-        item.putNull(TOSTRING_PATH);
-      }
-    }
 
     String result = issueUpdated.parse(parameters, node);
 

--- a/src/test/resources/parser/issueUpdatedJiraParser/issueUpdatedEpicNullMessageML.xml
+++ b/src/test/resources/parser/issueUpdatedJiraParser/issueUpdatedEpicNullMessageML.xml
@@ -1,0 +1,50 @@
+<entity type="com.symphony.integration.jira.event.updated" version="1.0">
+<presentationML>Test User updated Bug SAM-24, Sample Bug Blocker (<a href="https://whiteam1.atlassian.net/browse/SAM-24"/>) to <b>Done</b><br/>Assignee: <mention email="test@symphony.com"/><br/>Labels: <hash tag="production"/><br/>Priority: Highest<br/>Status: Done<br/>Description: </presentationML>
+<entity name="user" type="com.symphony.integration.jira.user" version="1.0">
+<attribute name="username" type="org.symphonyoss.string" value="test"/>
+<attribute name="emailAddress" type="org.symphonyoss.string" value="test@symphony.com"/>
+<attribute name="displayName" type="org.symphonyoss.string" value="Test User"/>
+<entity type="com.symphony.mention" version="1.0">
+<attribute name="id" type="org.symphony.oss.number.long" value="7627861918843"/>
+<attribute name="name" type="org.symphonyoss.string" value="Test User"/>
+</entity>
+</entity>
+<entity type="com.symphony.integration.jira.labels" version="1.0">
+<attribute name="production" type="org.symphonyoss.string" value="production"/>
+</entity>
+<entity type="com.symphony.integration.jira.issue" version="1.0">
+<attribute name="project" type="org.symphonyoss.string" value="Sample 1"/>
+<attribute name="key" type="org.symphonyoss.string" value="SAM-24"/>
+<attribute name="subject" type="org.symphonyoss.string" value="Sample Bug Blocker"/>
+<attribute name="type" type="org.symphonyoss.string" value="Bug"/>
+<attribute name="link" type="com.symphony.uri" value="https://whiteam1.atlassian.net/browse/SAM-24"/>
+<attribute name="priority" type="org.symphonyoss.string" value="Highest"/>
+<attribute name="status" type="org.symphonyoss.string" value="Done"/>
+<entity name="assignee" type="com.symphony.integration.jira.user" version="1.0">
+<attribute name="username" type="org.symphonyoss.string" value="test"/>
+<attribute name="emailAddress" type="org.symphonyoss.string" value="test@symphony.com"/>
+<attribute name="displayName" type="org.symphonyoss.string" value="Test User"/>
+<entity type="com.symphony.mention" version="1.0">
+<attribute name="id" type="org.symphony.oss.number.long" value="7627861918843"/>
+<attribute name="name" type="org.symphonyoss.string" value="Test User"/>
+</entity>
+</entity>
+</entity>
+<entity type="com.symphony.integration.jira.changelog" version="1.0">
+<entity type="com.symphony.integration.jira.change" version="1.0">
+<attribute name="fieldName" type="org.symphonyoss.string" value="resolution"/>
+<attribute name="oldValue" type="org.symphonyoss.string" value="null"/>
+<attribute name="newValue" type="org.symphonyoss.string" value="Done"/>
+</entity>
+<entity type="com.symphony.integration.jira.change" version="1.0">
+<attribute name="fieldName" type="org.symphonyoss.string" value="status"/>
+<attribute name="oldValue" type="org.symphonyoss.string" value="To Do"/>
+<attribute name="newValue" type="org.symphonyoss.string" value="Done"/>
+</entity>
+<entity type="com.symphony.integration.jira.change" version="1.0">
+<attribute name="fieldName" type="org.symphonyoss.string" value="Epic Link"/>
+<attribute name="oldValue" type="org.symphonyoss.string" value="EPIC-123"/>
+<attribute name="newValue" type="org.symphonyoss.string" value=""/>
+</entity>
+</entity>
+</entity>

--- a/src/test/resources/parser/issueUpdatedJiraParser/jiraCallbackSampleIssueEpicUpdated.json
+++ b/src/test/resources/parser/issueUpdatedJiraParser/jiraCallbackSampleIssueEpicUpdated.json
@@ -1,0 +1,282 @@
+{
+  "timestamp": 1463428118680,
+  "webhookEvent": "jira:issue_updated",
+  "issue_event_type_name": "issue_generic",
+  "user": {
+    "self": "https://whiteam1.atlassian.net/rest/api/2/user?username=test",
+    "name": "test",
+    "key": "test",
+    "emailAddress": "test@symphony.com",
+    "avatarUrls": {
+      "48x48": "https://secure.gravatar.com/avatar/b09ce1d21b19c1390c08ee92cfc6dfd7?d=mm&s=48",
+      "24x24": "https://secure.gravatar.com/avatar/b09ce1d21b19c1390c08ee92cfc6dfd7?d=mm&s=24",
+      "16x16": "https://secure.gravatar.com/avatar/b09ce1d21b19c1390c08ee92cfc6dfd7?d=mm&s=16",
+      "32x32": "https://secure.gravatar.com/avatar/b09ce1d21b19c1390c08ee92cfc6dfd7?d=mm&s=32"
+    },
+    "displayName": "Test User",
+    "active": true,
+    "timeZone": "America/Sao_Paulo"
+  },
+  "issue": {
+    "id": "10023",
+    "self": "https://whiteam1.atlassian.net/rest/api/2/issue/10023",
+    "key": "SAM-24",
+    "fields": {
+      "issuetype": {
+        "self": "https://whiteam1.atlassian.net/rest/api/2/issuetype/10004",
+        "id": "10004",
+        "description": "A problem which impairs or prevents the functions of the product.",
+        "iconUrl": "https://whiteam1.atlassian.net/secure/viewavatar?size=xsmall&avatarId=10303&avatarType=issuetype",
+        "name": "Bug",
+        "subtask": false,
+        "avatarId": 10303
+      },
+      "timespent": null,
+      "project": {
+        "self": "https://whiteam1.atlassian.net/rest/api/2/project/10000",
+        "id": "10000",
+        "key": "SAM",
+        "name": "Sample 1",
+        "avatarUrls": {
+          "48x48": "https://whiteam1.atlassian.net/secure/projectavatar?avatarId=10324",
+          "24x24": "https://whiteam1.atlassian.net/secure/projectavatar?size=small&avatarId=10324",
+          "16x16": "https://whiteam1.atlassian.net/secure/projectavatar?size=xsmall&avatarId=10324",
+          "32x32": "https://whiteam1.atlassian.net/secure/projectavatar?size=medium&avatarId=10324"
+        }
+      },
+      "fixVersions": [],
+      "aggregatetimespent": null,
+      "resolution": {
+        "self": "https://whiteam1.atlassian.net/rest/api/2/resolution/10000",
+        "id": "10000",
+        "description": "Work has been completed on this issue.",
+        "name": "Done"
+      },
+      "resolutiondate": "2016-05-16T16:48:38.674-0300",
+      "workratio": -1,
+      "lastViewed": "2016-05-16T16:48:38.653-0300",
+      "watches": {
+        "self": "https://whiteam1.atlassian.net/rest/api/2/issue/SAM-24/watchers",
+        "watchCount": 1,
+        "isWatching": true
+      },
+      "created": "2016-05-16T16:46:37.007-0300",
+      "customfield_10020": null,
+      "customfield_10021": "Not started",
+      "customfield_10022": null,
+      "priority": {
+        "self": "https://whiteam1.atlassian.net/rest/api/2/priority/1",
+        "iconUrl": "https://whiteam1.atlassian.net/images/icons/priorities/highest.svg",
+        "name": "Highest",
+        "id": "1"
+      },
+      "labels": [
+        "#production"
+      ],
+      "customfield_10016": null,
+      "customfield_10017": null,
+      "customfield_10018": null,
+      "customfield_10019": null,
+      "timeestimate": null,
+      "aggregatetimeoriginalestimate": null,
+      "versions": [
+        {
+          "self": "https://whiteam1.atlassian.net/rest/api/2/version/10000",
+          "id": "10000",
+          "name": "Version 1.0",
+          "archived": false,
+          "released": true,
+          "releaseDate": "2016-05-09"
+        }
+      ],
+      "issuelinks": [
+        {
+          "id": "10003",
+          "self": "https://whiteam1.atlassian.net/rest/api/2/issueLink/10003",
+          "type": {
+            "id": "10000",
+            "name": "Blocks",
+            "inward": "is blocked by",
+            "outward": "blocks",
+            "self": "https://whiteam1.atlassian.net/rest/api/2/issueLinkType/10000"
+          },
+          "outwardIssue": {
+            "id": "10012",
+            "key": "SAM-13",
+            "self": "https://whiteam1.atlassian.net/rest/api/2/issue/10012",
+            "fields": {
+              "summary": "As a developer, I can update details on an item using the Detail View >> Click the \"SAM-13\" link at the top of this card to open the detail view",
+              "status": {
+                "self": "https://whiteam1.atlassian.net/rest/api/2/status/10000",
+                "description": "",
+                "iconUrl": "https://whiteam1.atlassian.net/",
+                "name": "To Do",
+                "id": "10000",
+                "statusCategory": {
+                  "self": "https://whiteam1.atlassian.net/rest/api/2/statuscategory/2",
+                  "id": 2,
+                  "key": "new",
+                  "colorName": "blue-gray",
+                  "name": "To Do"
+                }
+              },
+              "priority": {
+                "self": "https://whiteam1.atlassian.net/rest/api/2/priority/3",
+                "iconUrl": "https://whiteam1.atlassian.net/images/icons/priorities/medium.svg",
+                "name": "Medium",
+                "id": "3"
+              },
+              "issuetype": {
+                "self": "https://whiteam1.atlassian.net/rest/api/2/issuetype/10004",
+                "id": "10004",
+                "description": "A problem which impairs or prevents the functions of the product.",
+                "iconUrl": "https://whiteam1.atlassian.net/secure/viewavatar?size=xsmall&avatarId=10303&avatarType=issuetype",
+                "name": "Bug",
+                "subtask": false,
+                "avatarId": 10303
+              }
+            }
+          }
+        }
+      ],
+      "assignee": {
+        "self": "https://whiteam1.atlassian.net/rest/api/2/user?username=test2",
+        "name": "test2",
+        "key": "test2",
+        "emailAddress": "test2@symphony.com",
+        "avatarUrls": {
+          "48x48": "https://secure.gravatar.com/avatar/b09ce1d21b19c1390c08ee92cfc6dfd7?d=mm&s=48",
+          "24x24": "https://secure.gravatar.com/avatar/b09ce1d21b19c1390c08ee92cfc6dfd7?d=mm&s=24",
+          "16x16": "https://secure.gravatar.com/avatar/b09ce1d21b19c1390c08ee92cfc6dfd7?d=mm&s=16",
+          "32x32": "https://secure.gravatar.com/avatar/b09ce1d21b19c1390c08ee92cfc6dfd7?d=mm&s=32"
+        },
+        "displayName": "Test2 User",
+        "active": true,
+        "timeZone": "America/Sao_Paulo"
+      },
+      "updated": "2016-05-16T16:48:38.678-0300",
+      "status": {
+        "self": "https://whiteam1.atlassian.net/rest/api/2/status/10001",
+        "description": "",
+        "iconUrl": "https://whiteam1.atlassian.net/",
+        "name": "Done",
+        "id": "10001",
+        "statusCategory": {
+          "self": "https://whiteam1.atlassian.net/rest/api/2/statuscategory/3",
+          "id": 3,
+          "key": "done",
+          "colorName": "green",
+          "name": "Done"
+        }
+      },
+      "components": [],
+      "timeoriginalestimate": null,
+      "description": null,
+      "customfield_10010": null,
+      "customfield_10011": null,
+      "customfield_10012": null,
+      "customfield_10013": null,
+      "customfield_10014": null,
+      "timetracking": {},
+      "customfield_10015": null,
+      "attachment": [],
+      "customfield_10009": "com.atlassian.servicedesk.plugins.approvals.internal.customfield.ApprovalsCFValue@3e5d43",
+      "aggregatetimeestimate": null,
+      "summary": "Sample Bug Blocker",
+      "creator": {
+        "self": "https://whiteam1.atlassian.net/rest/api/2/user?username=test",
+        "name": "test",
+        "key": "test",
+        "emailAddress": "test@symphony.com",
+        "avatarUrls": {
+          "48x48": "https://secure.gravatar.com/avatar/b09ce1d21b19c1390c08ee92cfc6dfd7?d=mm&s=48",
+          "24x24": "https://secure.gravatar.com/avatar/b09ce1d21b19c1390c08ee92cfc6dfd7?d=mm&s=24",
+          "16x16": "https://secure.gravatar.com/avatar/b09ce1d21b19c1390c08ee92cfc6dfd7?d=mm&s=16",
+          "32x32": "https://secure.gravatar.com/avatar/b09ce1d21b19c1390c08ee92cfc6dfd7?d=mm&s=32"
+        },
+        "displayName": "Milton  [Administrator]",
+        "active": true,
+        "timeZone": "America/Sao_Paulo"
+      },
+      "subtasks": [],
+      "reporter": {
+        "self": "https://whiteam1.atlassian.net/rest/api/2/user?username=test",
+        "name": "test",
+        "key": "test",
+        "emailAddress": "test@symphony.com",
+        "avatarUrls": {
+          "48x48": "https://secure.gravatar.com/avatar/b09ce1d21b19c1390c08ee92cfc6dfd7?d=mm&s=48",
+          "24x24": "https://secure.gravatar.com/avatar/b09ce1d21b19c1390c08ee92cfc6dfd7?d=mm&s=24",
+          "16x16": "https://secure.gravatar.com/avatar/b09ce1d21b19c1390c08ee92cfc6dfd7?d=mm&s=16",
+          "32x32": "https://secure.gravatar.com/avatar/b09ce1d21b19c1390c08ee92cfc6dfd7?d=mm&s=32"
+        },
+        "displayName": "Milton  [Administrator]",
+        "active": true,
+        "timeZone": "America/Sao_Paulo"
+      },
+      "customfield_10000": null,
+      "aggregateprogress": {
+        "progress": 0,
+        "total": 0
+      },
+      "customfield_10001": "10000_*:*_1_*:*_121671_*|*_10001_*:*_1_*:*_0",
+      "customfield_10002": "0|i00053:",
+      "customfield_10003": [
+        "com.atlassian.greenhopper.service.sprint.Sprint@1323766[id=1,rapidViewId=1,state=ACTIVE,name=Sample Sprint 2,startDate=2016-05-09T07:21:05.375-03:00,endDate=2016-05-23T07:41:05.375-03:00,completeDate=<null>,sequence=1]"
+      ],
+      "customfield_10004": null,
+      "environment": null,
+      "duedate": null,
+      "progress": {
+        "progress": 0,
+        "total": 0
+      },
+      "comment": {
+        "startAt": 0,
+        "maxResults": 0,
+        "total": 0,
+        "comments": []
+      },
+      "votes": {
+        "self": "https://whiteam1.atlassian.net/rest/api/2/issue/SAM-24/votes",
+        "votes": 0,
+        "hasVoted": false
+      },
+      "worklog": {
+        "startAt": 0,
+        "maxResults": 20,
+        "total": 0,
+        "worklogs": []
+      }
+    }
+  },
+  "changelog": {
+    "id": "10029",
+    "items": [
+      {
+        "field": "resolution",
+        "fieldtype": "jira",
+        "from": null,
+        "fromString": null,
+        "to": "10000",
+        "toString": "Done"
+      },
+      {
+        "field": "status",
+        "fieldtype": "jira",
+        "from": "10000",
+        "fromString": "To Do",
+        "to": "10001",
+        "toString": "Done"
+      },
+      {
+        "field": "Epic Link",
+        "fieldtype": "custom",
+        "from": "10000",
+        "fromString": "EPIC-123",
+        "to": "EPIC-999",
+        "toString": "EPIC-999"
+      }
+    ]
+  }
+}

--- a/src/test/resources/parser/issueUpdatedJiraParser/jiraCallbackSampleIssueEpicUpdated.json
+++ b/src/test/resources/parser/issueUpdatedJiraParser/jiraCallbackSampleIssueEpicUpdated.json
@@ -274,8 +274,8 @@
         "fieldtype": "custom",
         "from": "10000",
         "fromString": "EPIC-123",
-        "to": "EPIC-999",
-        "toString": "EPIC-999"
+        "to": null,
+        "toString": null
       }
     ]
   }


### PR DESCRIPTION
To prevent an addition of a NULL json value, it's important to check that using the method isNull(). When an epic link is updated to none, JIRA sends NULL as value, and an invalid link has been displayed. Now the link is rendered only if a valid EPIC is informed.