### PR TITLE
PLAT-7359 - Block empty comments

### DIFF
--- a/src/main/java/org/symphonyoss/integration/jira/services/CommonJiraService.java
+++ b/src/main/java/org/symphonyoss/integration/jira/services/CommonJiraService.java
@@ -107,7 +107,7 @@ public abstract class CommonJiraService {
    * Thrown {@link InvalidJiraCommentException} exception
    */
   public void validateComment(String comment) {
-    if (StringUtils.isEmpty(comment)) {
+    if (StringUtils.isEmpty(comment.trim())) {
       String message = MSG.getMessage(INVALID_COMMENT);
       String solution = MSG.getMessage(INVALID_COMMENT_SOLUTION);
 

--- a/src/main/webapp/services/commentService.js
+++ b/src/main/webapp/services/commentService.js
@@ -86,7 +86,7 @@ export default class CommentService extends BaseService {
     const commentTemplate = commentDialog({ commentText: this.comment });
     const dialogBuilder = new DialogBuilder('Comment on', commentTemplate);
 
-    if (this.comment === '') {
+    if (this.comment.trim() === '') {
       dialogBuilder.error('Invalid comment');
 
       const template = this.retrieveTemplate(dialogBuilder, data, this.serviceName);


### PR DESCRIPTION
Jira REST API returns 400 when the comment (trim) is empty. Therefore this check must be made before sending it to Jira's API
However, we can't always trim the comment, to avoid erasing the user comment format